### PR TITLE
update README: link to recent version of esp-idf setup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Before you get started you will need to follow the setup documentation from
 the [esp-idf](https://github.com/espressif/esp-idf/tree/master/docs) project
 for your specific operating system.
 
-I have only tested this on macOS and using the most recent version of
+I have only tested this on macOS and using a certain version of
 [esp-idf](https://github.com/espressif/esp-idf/tree/abecab7525e7edb1fde16ab5d8cf7b368b1d332c).
+You should try to use [more recent version](https://github.com/espressif/esp-idf#setting-up-esp-idf) if you have failed.
 
 You will need to recursively clone this project with the recursive flag
 because it includes mruby as a submodule:


### PR DESCRIPTION
I had read the docs of [esp-idf site linked from this README](https://github.com/espressif/esp-idf/tree/abecab7525e7edb1fde16ab5d8cf7b368b1d332c) and [setup guide](https://github.com/espressif/esp-idf/blob/abecab7525e7edb1fde16ab5d8cf7b368b1d332c/docs/macos-setup.rst) to make a developing environment, but I could not do it because there was (maybe) some incompatibility between ESP-IDF and xtense GNU toolchain.
After that I noticed the link is a bit old.  I tried again with [current setup page](https://github.com/espressif/esp-idf#setting-up-esp-idf) and now I can.

IMHO, even if you don't use newer version of ESP-IDF, it might be better to recommend current ESP-IDF to users, like this PR.