### PR TITLE
Update to mruby 2.1

### DIFF
--- a/components/mruby_component/esp32_build_config.rb
+++ b/components/mruby_component/esp32_build_config.rb
@@ -39,6 +39,7 @@ MRuby::CrossBuild.new('esp32') do |conf|
     cc.defines << %w(KHASH_DEFAULT_SIZE=8)
     cc.defines << %w(MRB_STR_BUF_MIN_SIZE=20)
     cc.defines << %w(MRB_GC_STRESS)
+    cc.defines << %w(MRB_METHOD_T_STRUCT)
 
     cc.defines << %w(ESP_PLATFORM)
   end


### PR DESCRIPTION
As of https://github.com/mruby/mruby/commit/2256bb07b02c9025ed7ea1fee8c21c86104c07dc
this requires defining MRB_METHOD_T_STRUCT or else mruby will crash
inside mrb_open.

Prior to this commit, you could optin to inline method table by defining
MRB_METHOD_TABLE_INLINE which appears not work on esp32, however as of
the above commit, this became the default and MRB_METHOD_T_STRUCT must be
defined to opt out