### PR TITLE
Add delay() to avoid Task WDT.

### DIFF
--- a/main/mruby_main.c
+++ b/main/mruby_main.c
@@ -36,6 +36,7 @@ void mruby_task(void *pvParameter)
   // This task should never end, even if the
   // script ends.
   while (1) {
+    vTaskDelay(1);
   }
 }
 


### PR DESCRIPTION
### Environment

ESP-IDF: v4.2
MCU: ESP32-WROOM-32

### Phenomena

After building and flashing mruby-esp32 and connecting to serial, I got the following log.

```
boot: ESP-IDF v4.2.2-421-gfccaf93a87 2nd stage bootloader
I (29) boot: compile time 11:38:04
I (29) boot: chip revision: 1
I (33) boot_comm: chip revision: 1, min. bootloader chip revision: 0
I (40) boot.esp32: SPI Speed      : 40MHz
I (45) boot.esp32: SPI Mode       : DIO
I (49) boot.esp32: SPI Flash Size : 4MB
I (54) boot: Enabling RNG early entropy source...
I (59) boot: Partition Table:
I (63) boot: ## Label            Usage          Type ST Offset   Length
I (70) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (78) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (85) boot:  2 factory          factory app      00 00 00010000 00100000
I (93) boot: End of partition table
I (97) boot_comm: chip revision: 1, min. application chip revision: 0
I (104) esp_image: segment 0: paddr=0x00010020 vaddr=0x3f400020 size=0x1fe30 (130608) map
I (162) esp_image: segment 1: paddr=0x0002fe58 vaddr=0x3ffb0000 size=0x001c0 (   448) load
I (163) esp_image: segment 2: paddr=0x00030020 vaddr=0x400d0020 size=0x91124 (594212) map
I (393) esp_image: segment 3: paddr=0x000c114c vaddr=0x3ffb01c0 size=0x03670 ( 13936) load
I (399) esp_image: segment 4: paddr=0x000c47c4 vaddr=0x40080000 size=0x16134 ( 90420) load
I (439) esp_image: segment 5: paddr=0x000da900 vaddr=0x400c0000 size=0x00064 (   100) load
I (452) boot: Loaded app from partition at offset 0x10000
I (452) boot: Disabling RNG early entropy source...
I (452) cpu_start: Pro cpu up.
I (456) cpu_start: Application information:
I (461) cpu_start: Project name:     mruby_example
I (466) cpu_start: App version:      f390668-dirty
I (472) cpu_start: Compile time:     Nov 28 2021 11:38:16
I (478) cpu_start: ELF file SHA256:  221eff7b244ad9c5...
I (484) cpu_start: ESP-IDF:          v4.2.2-421-gfccaf93a87
I (490) cpu_start: Starting app cpu, entry point is 0x40081314
I (0) cpu_start: App cpu up.
I (500) heap_init: Initializing. RAM available for dynamic allocation:
I (507) heap_init: At 3FFAE6E0 len 00001920 (6 KiB): DRAM
I (513) heap_init: At 3FFB7DF8 len 00028208 (160 KiB): DRAM
I (519) heap_init: At 3FFE0440 len 00003AE0 (14 KiB): D/IRAM
I (526) heap_init: At 3FFE4350 len 0001BCB0 (111 KiB): D/IRAM
I (532) heap_init: At 40096134 len 00009ECC (39 KiB): IRAM
I (538) cpu_start: Pro cpu start user code
I (557) spi_flash: detected chip: gd
I (557) spi_flash: flash io: dio
I (558) cpu_start: Starting scheduler on PRO CPU.
I (0) cpu_start: Starting scheduler on APP CPU.
I (200) mruby_task: Loading binary...
1234
4321
I (210) mruby_task: Success
E (10604) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (10604) task_wdt:  - IDLE1 (CPU 1)
E (10604) task_wdt: Tasks currently running:
E (10604) task_wdt: CPU 0: IDLE0
E (10604) task_wdt: CPU 1: mruby_task
E (10604) task_wdt: Print CPU 0 (current core) backtrace


Backtrace:0x400D316C:0x3FFB08A0 0x40082409:0x3FFB08C0 0x4015ED43:0x3FFBAE40 0x400D33F6:0x3FFBAE60 0x40087E79:0x3FFBAE80 0x400898D5:0x3FFBAEA0

E (10604) task_wdt: Print CPU 1 backtrace


Backtrace:0x400815C7:0x3FFB10A0 0x40082409:0x3FFB10C0 0x400D3D36:0x3FFBE8C0 0x400898D5:0x3FFBE8E0

E (15604) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (15604) task_wdt:  - IDLE1 (CPU 1)
E (15604) task_wdt: Tasks currently running:
E (15604) task_wdt: CPU 0: IDLE0
E (15604) task_wdt: CPU 1: mruby_task
E (15604) task_wdt: Print CPU 0 (current core) backtrace


Backtrace:0x400D316C:0x3FFB08A0 0x40082409:0x3FFB08C0 0x4015ED43:0x3FFBAE40 0x400D33F6:0x3FFBAE60 0x40087E79:0x3FFBAE80 0x400898D5:0x3FFBAEA0

E (15604) task_wdt: Print CPU 1 backtrace


Backtrace:0x400815C7:0x3FFB10A0 0x40082409:0x3FFB10C0 0x400D3D36:0x3FFBE8C0 0x400898D5:0x3FFBE8E0
```

### Revision

I'm guessing that the cause is that the infinite loop after program execution is empty and continues to occupy core. For this reason, I modified the code to call vTaskDelay() inside the while.