### PR TITLE
Fixed panic when an Exception is raised into mruby.

### DIFF
--- a/main/mruby_main.c
+++ b/main/mruby_main.c
@@ -37,7 +37,8 @@ void mruby_task(void *pvParameter)
   }
   load(mrb, fp, context);
   if (mrb->exc) {
-    ESP_LOGE(TAG, "Exception occurred: %s", mrb_str_to_cstr(mrb, mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+    ESP_LOGE(TAG, "Exception occurred");
+    mrb_print_error(mrb);
     mrb->exc = 0;
   } else {
     ESP_LOGI(TAG, "%s", "Success");


### PR DESCRIPTION
If an Exception raised in a mruby program is not rescued, the cpu will panic.

```
I (633) cpu_start: App cpu up.
I (663) cpu_start: Pro cpu start user code
I (663) cpu_start: cpu freq: 160000000 Hz
I (663) cpu_start: Application information:
I (668) cpu_start: Project name:     mruby-esp32
I (673) cpu_start: App version:      20230121082950-6-g74f7ce1-dirty
I (680) cpu_start: Compile time:     Jan 31 2023 06:19:47
I (686) cpu_start: ELF file SHA256:  647225c701bda527...
I (692) cpu_start: ESP-IDF:          v5.0-494-g490216a2ac
I (698) heap_init: Initializing. RAM available for dynamic allocation:
I (706) heap_init: At 3FFAE6E0 len 00001920 (6 KiB): DRAM
I (711) heap_init: At 3FFB79D0 len 00028630 (161 KiB): DRAM
I (718) heap_init: At 3FFE0440 len 00003AE0 (14 KiB): D/IRAM
I (724) heap_init: At 3FFE4350 len 0001BCB0 (111 KiB): D/IRAM
I (731) heap_init: At 40095AF4 len 0000A50C (41 KiB): IRAM
I (738) spi_flash: detected chip: generic
I (741) spi_flash: flash io: dio
W (745) spi_flash: Detected size(4096k) larger than the size in the binary image header(2048k). Using the size in the binary image header.
I (760) cpu_start: Starting scheduler on PRO CPU.
I (0) cpu_start: Starting scheduler on APP CPU.
I (280) mruby_task: Loading...
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x400f5414  PS      : 0x00060630  A0      : 0x800f5214  A1      : 0x3ffbfba0  
0x400f5414: mrb_funcall_with_block at ??:?

A2      : 0x0000000b  A3      : 0x3ffbffa0  A4      : 0x00000013  A5      : 0xffffffff  
A6      : 0x3ffc5314  A7      : 0x00000000  A8      : 0x800f5125  A9      : 0x3ffbf5e0  
A10     : 0x3ffbfe20  A11     : 0x3ffc020c  A12     : 0x00000012  A13     : 0x00000006  
A14     : 0x00000000  A15     : 0x3ffafcc4  SAR     : 0x00000016  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000000  LBEG    : 0x4000c46c  LEND    : 0x4000c477  LCOUNT  : 0x00000000  


Backtrace: 0x400f5411:0x3ffbfba0 0x400f5211:0x3ffbfcd0 0x400f596b:0x3ffbfe00 0x400deb01:0x3ffbffa0 0x400d6f4b:0x3ffc0000 0x4008cb8d:0x3ffc0020
0x400f5411: mrb_funcall_with_block at ??:?

0x400f5211: mrb_funcall_with_block at ??:?

0x400f596b: mrb_funcall_id at ??:?

0x400deb01: mrb_inspect at ??:?

0x400d6f4b: mruby_task at /Users/yuhei/ghq/github.com/yuuu/mruby-esp32/main/mruby_main.c:40 (discriminator 3)

0x4008cb8d: vPortTaskWrapper at /Users/yuhei/ghq/github.com/espressif/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:154





ELF file SHA256: 647225c701bda527

Rebooting...
```

The backtrace shows that the cause is `mrb_inspect()`.
So I modified it to print the error to stdout by using `mrb_print_error()` instead of `mrb_inspect()`.

This modification changes the log output destination to standard output. I believe this is the preferred behavior, as this is the log that users should be informed about.