### PR TITLE
Removed block for callback on connection from MQTT publish example.

### DIFF
--- a/main/examples/mqtt_publish.rb
+++ b/main/examples/mqtt_publish.rb
@@ -1,20 +1,14 @@
 wifi = ESP32::WiFi.new
 
-wifi.on_connected do |ip|
-  puts "Connected: #{ip}"
-
-  mqtt = ESP32::MQTT::Client.new('test.mosquitto.org', 1883)
-  mqtt.connect
-  mqtt.publish("mruby-esp32-mqtt", '{ "hello": "world." }')
-  mqtt.disconnect
-end
-
-wifi.on_disconnected do
-  puts 'Disconnected'
-end
-
 puts 'Connecting to wifi'
 wifi.connect('SSID', 'password')
+
+puts "Connected"
+
+mqtt = ESP32::MQTT::Client.new('test.mosquitto.org', 1883)
+mqtt.connect
+mqtt.publish("mruby-esp32-mqtt", '{ "hello": "world." }')
+mqtt.disconnect
 
 #
 # Loop forever otherwise the script ends


### PR DESCRIPTION
ESP32::WiFi#connect is now synchronous.
Therefore, ESP32::WiFi#connect in examples/mqtt_publish.rb has also been changed to synchronous usage.