### PR TITLE
Add the new esp_adc component for the updated GPIO gem

### DIFF
--- a/components/mruby_component/CMakeLists.txt
+++ b/components/mruby_component/CMakeLists.txt
@@ -4,7 +4,7 @@ set(MRUBY_CONFIG ${COMPONENT_DIR}/esp32_build_config.rb)
 
 idf_component_register(
   INCLUDE_DIRS mruby/include
-  REQUIRES esp_hw_support esp_rom esp_timer esp_wifi driver mqtt
+  REQUIRES esp_hw_support esp_rom esp_timer driver esp_adc esp_wifi mqtt
 )
 
 add_custom_command(
@@ -17,7 +17,7 @@ add_custom_command(
 
 add_prebuilt_library(
   libmruby ${LIBMRUBY_FILE}
-  PRIV_REQUIRES esp_hw_support esp_rom esp_timer esp_wifi driver mqtt
+  PRIV_REQUIRES esp_hw_support esp_rom esp_timer driver esp_adc esp_wifi mqtt
 )
 target_link_libraries(${COMPONENT_LIB} INTERFACE libmruby)
 


### PR DESCRIPTION
Merge this PR only when [this other PR](https://github.com/mruby-esp32/mruby-esp32-gpio/pull/14) has been merged, **and** merged into the `0.5` branch of that gem.

This repo uses that `0.5` branch as its source for the GPIO gem.

This PR adds the up-to-date `esp_adc` component to the IDF project, which the updated GPIO gem will need to work.