### PR TITLE
Add/improve MQTT examples for event driven update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Replace `EXAMPLE_FILENAME` with one of the following:
   * `wifi_connect.rb` - Connects to WiFi
   * `wifi_socket.rb` - Connects to WiFi and makes a TCPSocket connection
   * `mqtt_publish.rb` - Connects to WiFi and publishes to MQTT broker
+  * `mqtt_subscribe.rb` - Connects to WiFi, subscribes to MQTT broker, and prints received messages
+  * `mqtt_led_servo.rb` - Receives microsecond values over MQTT and writes them to a servo, while blinking LED in main loop
   * `filesystem.rb` - Write/append/read a file on the virtual filesystem
   * `ledc_breathe.rb` - Gradually fades the brightness of an LED up and down
   * `ledc_buzzer.rb` - Plays a melody on a piezo-electric buzzer

--- a/main/examples/mqtt_led_servo.rb
+++ b/main/examples/mqtt_led_servo.rb
@@ -1,0 +1,56 @@
+#
+# Servo Setup
+#
+group = ESP32::LEDC_LOW_SPEED_MODE
+channel = ESP32::LEDC_CHANNEL_0
+timer = ESP32::LEDC_TIMER_0
+resolution = ESP32::LEDC_TIMER_14_BIT
+pin = ESP32::GPIO_NUM_4
+frequency = 50
+
+# Configure the channel and timer.
+ESP32::LEDC.channel_config(pin, group, timer, channel)
+ESP32::LEDC.timer_config(group, timer, resolution, frequency)
+
+# Using 14-bit PWM @ 50Hz, 0-16383 maps from 0 to 20 milliseconds.
+# Calculate how many microseconds each LSB of duty cycle represents.
+US_PER_BIT = (1000000.0 / frequency) / (2 ** resolution)
+
+# Convert from microseconds to duty cycle.
+def microseconds_to_duty(us)
+  (us / US_PER_BIT).round
+end
+
+#
+# WiFi Setup
+#
+print 'Connecting to wifi...'
+wifi = ESP32::WiFi.new
+wifi.connect('SSID', 'password')
+puts "Connected"
+
+#
+# MQTT Setup
+#
+mqtt = ESP32::MQTT::Client.new('test.mosquitto.org', 1883)
+mqtt.connect
+mqtt.subscribe("mruby-esp32-mqtt") do |message|
+  puts "Servo mircoseconds: #{message}"
+  # Send microsecond values to move the servo.
+  ESP32::LEDC.set_duty(group, channel, microseconds_to_duty(message.to_i))
+end
+
+#
+# Blink LED in main loop.
+#
+led = ESP32::GPIO_NUM_2
+ESP32::GPIO::pinMode(led, ESP32::GPIO::OUTPUT)
+loop do
+  ESP32::GPIO::digitalWrite(led, ESP32::GPIO::HIGH)
+  ESP32::System.delay(1000)
+  ESP32::GPIO::digitalWrite(led, ESP32::GPIO::LOW)
+  ESP32::System.delay(1000)
+end
+
+# Send a message using another MQTT client, or a site like:
+# https://testclient-cloud.mqtt.cool/

--- a/main/examples/mqtt_publish.rb
+++ b/main/examples/mqtt_publish.rb
@@ -1,8 +1,6 @@
+print 'Connecting to wifi...'
 wifi = ESP32::WiFi.new
-
-puts 'Connecting to wifi'
 wifi.connect('SSID', 'password')
-
 puts "Connected"
 
 mqtt = ESP32::MQTT::Client.new('test.mosquitto.org', 1883)

--- a/main/examples/mqtt_subscribe.rb
+++ b/main/examples/mqtt_subscribe.rb
@@ -1,0 +1,20 @@
+TOPIC = "mruby-esp32-mqtt"
+
+print 'Connecting to wifi...'
+wifi = ESP32::WiFi.new
+wifi.connect('SSID', 'password')
+puts "Connected"
+
+mqtt = ESP32::MQTT::Client.new('test.mosquitto.org', 1883)
+mqtt.connect
+mqtt.subscribe(TOPIC) do |message|
+  puts "Topic: #{topic}, message: #{message}"
+end
+
+# Message receive is event driven, so main loop can do whatever.
+loop do
+  ESP32::System.delay(1000)
+end
+
+# Send a message using another MQTT client, or a site like:
+# https://testclient-cloud.mqtt.cool/


### PR DESCRIPTION
I have an [open PR](https://github.com/mruby-esp32/mruby-esp32-mqtt/pull/2) to make the subscribe part of the MQTT gem event driven. This updates and adds examples to take advantage of that. Merge this PR after that one is merged.