### PR TITLE
Add ADC class.

### DIFF
--- a/components/mruby_component/esp32_build_config.rb
+++ b/components/mruby_component/esp32_build_config.rb
@@ -70,6 +70,7 @@ MRuby::CrossBuild.new('esp32') do |conf|
   conf.gem :github => "mruby-esp32/mruby-esp32-mqtt"
   
   conf.gem :github => "mruby-esp32/mruby-esp32-gpio"
+  conf.gem :github => "mruby-esp32/mruby-esp32-adc"
   conf.gem :github => "mruby-esp32/mruby-esp32-ledc"
   conf.gem :github => "mruby-esp32/mruby-esp32-spi"
 end

--- a/main/examples/adc.rb
+++ b/main/examples/adc.rb
@@ -1,0 +1,12 @@
+adc1 = ADC.new(ADC::CHANNEL_0, unit: ADC::UNIT_1)
+adc2 = ADC.new(ADC::CHANNEL_3, unit: ADC::UNIT_1)
+
+loop do
+  value = adc1.read_raw
+  puts "ADC1: #{value}"
+
+  value = adc2.read_raw
+  puts "ADC2: #{value}"
+
+  ESP32::System.delay(1000)
+end


### PR DESCRIPTION
I added a PWM class according to the "peripheral class common specifications".
https://github.com/HirohitoHigashi/mruby_io_class_study/blob/main/mruby_io_ADC.md

As you know, mruby-esp32-gpio already has analog_read. I think in the future we should separate the methods from that class. The new class allows you to specify ADC_UNIT_1 and has slightly better performance because you don't have to set the config all over again.

The added mruby-esp32-adc is the following URL. Please review it.
https://github.com/mruby-esp32/mruby-esp32-adc